### PR TITLE
Fixed header background on large screens

### DIFF
--- a/app/assets/stylesheets/ppwm.scss
+++ b/app/assets/stylesheets/ppwm.scss
@@ -29,6 +29,7 @@ body {
   
   header {
     background: #171322 url(/header-bg.jpg) no-repeat center top;
+    background-size: cover;
     
     h1 {
       color: #fff;


### PR DESCRIPTION
Hey,
On large screen there is an issue with header background. I'm attaching screenshots before and after my fix. Hope you like it.

Best regards,
Oskar
![before](https://cloud.githubusercontent.com/assets/5034850/4034972/6af91166-2c8a-11e4-974c-57d1c8160530.png)
![Uploading after.png . . .]()
