### PR TITLE
Adding Motepair to the list of tools

### DIFF
--- a/app/views/welcome/_resources.md
+++ b/app/views/welcome/_resources.md
@@ -82,6 +82,7 @@ successfully pair-programming beyond your office.
 - [tmate](http://tmate.io/) Instant terminal sharing
 - [Nitrous.io](https://www.nitrous.io/) creates an online 'box' for running and editing code, and also runs port forwarding and syncing to your local computer so you can use desktop editors.
 - [TeamViewer](http://www.teamviewer.com/) screen-sharing app for Mac/Windows/Linux, allows remote control and you can change color/quality settings to improve latency. Free for personal use.
+- [Motepair](https://atom.io/packages/motepair) Motepair is a Atom package to enable remote pair programming using Atom editor.
 
 ### Sharing the (commit) credit
 


### PR DESCRIPTION
Adds a new tool we've built to enable remote pair programming using Atom editor.