### PR TITLE
Remove broken link

### DIFF
--- a/app/views/welcome/_resources.md
+++ b/app/views/welcome/_resources.md
@@ -27,8 +27,6 @@ successfully pair-programming beyond your office.
   "[Remote Pairing with ssh, tmux, and vim](http://blog.stevenhaddox.com/2012/04/11/remote-pairing-with-ssh-tmux-vim/)"
   blog post.
 - [CoderMatch](http://www.codermatch.me) is a site to find a pair programming buddy to code with locally or remotely.
-- [RubyPair.com](http://rubypair.com/) is a site to find someone to
-  pair with on Ruby projects.
 - [Emberpairs.com](http://emberpairs.com) is a site to find someone to pair
   with on Ember projects.
 - [Pair-with-me.herokuapp.com](http://pair-with-me.herokuapp.com/) is an


### PR DESCRIPTION
rubypair.com no longer links to an active site. The domain is unregistered.