### PR TITLE
Resource: remove Nitrous.io - service discontinued

### DIFF
--- a/app/views/welcome/_resources.md
+++ b/app/views/welcome/_resources.md
@@ -77,7 +77,6 @@ successfully pair-programming beyond your office.
 - [Floobits](https://floobits.com/) Floobits lets you use native editors to
   work on the same files as others in real-time.
 - [tmate](http://tmate.io/) Instant terminal sharing
-- [Nitrous.io](https://www.nitrous.io/) creates an online 'box' for running and editing code, and also runs port forwarding and syncing to your local computer so you can use desktop editors.
 - [TeamViewer](http://www.teamviewer.com/) screen-sharing app for Mac/Windows/Linux, allows remote control and you can change color/quality settings to improve latency. Free for personal use.
 - [Slack /pair command](https://github.com/techieshark/slack-pair) Slack slash command your team can use to see who is free to pair on what.
 


### PR DESCRIPTION
"We will be discontinuing the Nitrous Development Platform and Cloud IDE on November 14th, 2016. "