### PR TITLE
Adding Adaface PairPro under Tools

### DIFF
--- a/app/views/welcome/_resources.md
+++ b/app/views/welcome/_resources.md
@@ -30,6 +30,7 @@ successfully pair-programming beyond your office.
 - [Tuple's Pair Programming Guide](https://tuple.app/pair-programming-guide) Tips, tutorials, and resources for thoughtful pair programmers.
 
 ### Tools
+- [Adaface](https://www.adaface.com/pair-pro) Any browser any device shared code editor with compiler and video conferencing
 - [Tuple](https://tuple.app) macOS only screen sharing tool tailored for pair programming.
 - [tmux](https://tmux.github.io/) Allows more than one person to
   connect to a single terminal session.


### PR DESCRIPTION
Suggesting Adaface PairPro (remote code share with video conferencing, code compiler and screen share) to be included in Tools section